### PR TITLE
fix the bug of not showing consents in consent-list page

### DIFF
--- a/src/app/consent-list/consent-list.component.ts
+++ b/src/app/consent-list/consent-list.component.ts
@@ -26,9 +26,9 @@ export class ConsentListComponent implements OnInit {
     private router: Router,
   ) {}
   ngOnInit(): void {
-    this.patientService.current.subscribe({
+    this.patientService.currentPatientEverything$.subscribe({
       next: d => {
-        this.patient = d;
+        this.patient = d?.entry?.[0] ? (d.entry[0].resource as Patient) : null;
         this.reload();
         // if (d) {
         //   // console.log('Loaded patient.');

--- a/src/app/consent/consent-category-form-check/consent-category-form-check.component.ts
+++ b/src/app/consent/consent-category-form-check/consent-category-form-check.component.ts
@@ -58,8 +58,8 @@ export class ConsentCategoryFormCheckComponent implements OnInit, OnChanges {
           items
             .map(info => {
               return checked
-                ? `<span class="text-black">${info.display}</span>`
-                : `<span class="text-danger text-decoration-line-through">${info.display}</span>`;
+                ? `<span>${info.display}</span>`
+                : `<span>${info.display}</span>`;
             })
             .join('</li><li>') +
           '</li></ul>'


### PR DESCRIPTION
Now the code will send request to get everything with subject of Patient/[patient_id] through the everything operation, and I found that the patient with ID 195308 has a total of 7705 items of medical information. This extensive dataset includes various health records, diagnoses, treatments, and other relevant information related to the patient’s medical history.
[patient_195308.json](https://github.com/asushares/patient/files/15299564/patient_195308.json)
Maybe it is helpful to use it as a reference, so I attached the json here.
[document of patient everything operation](https://hl7.org/fhir/operation-patient-everything.html)